### PR TITLE
Add a fade-out effect + alphaSpeed

### DIFF
--- a/Sources/ConfettiKit/ConfettiView.swift
+++ b/Sources/ConfettiKit/ConfettiView.swift
@@ -39,7 +39,13 @@ public final class ConfettiView: UIView {
 
 extension ConfettiView: ShootingDelegate {
     func shootingDidFinish(_ shooting: Shooting) {
-        shooting.view?.removeFromSuperview()
-        shootings.removeAll { $0 === shooting }
+        guard let view = shooting.view else { return }
+        
+        UIView.animate(withDuration: 0.5, animations: {
+            view.alpha = 0.0
+        }, completion: { _ in
+            view.removeFromSuperview()
+            self.shootings.removeAll { $0 === shooting }
+        })
     }
 }

--- a/Sources/ConfettiKit/Internal/ConfettiLayerView.swift
+++ b/Sources/ConfettiKit/Internal/ConfettiLayerView.swift
@@ -85,6 +85,7 @@ private extension ConfettiLayerView {
         cell.scale = scale
         cell.scaleRange = scaleRange
         cell.speed = speed
+        cell.alphaSpeed = -0.4
         cell.emissionLongitude = degreesToRadians(180)
         cell.emissionRange = degreesToRadians(90)
         cell.contents = image.cgImage


### PR DESCRIPTION
For the center-to-edges mode, some confetti still appeared on the screen before the view was removed, so I added a fade-out effect to hide them more smoothly. Additionally, I applied an alphaSpeed setting to CAEmitterCell for a smoother alpha transition.